### PR TITLE
fix(filters): fixing some styling and click behavior

### DIFF
--- a/src/components/Checkbox/CheckBoxIcon.js
+++ b/src/components/Checkbox/CheckBoxIcon.js
@@ -26,7 +26,7 @@ const CheckBoxIcon = ({ isExpanded, translateWithId: t }) => {
         icon={iconChevronDown}
         description={description}
         alt={description}
-        name="iconName"
+        name="icon--chevron--down"
       />
     </div>
   );

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -45,13 +45,12 @@ const Checkbox = ({
         }}
       />
 
-      <label className={labelClasses} title={title || null} />
-      <span
-        className={innerLabelClasses}
-        style={{ position: 'absolute', marginLeft: '26px', width: '80%' }}>
-        {labelText}
-        {hasGroups && <CheckBoxIcon isExpanded={isExpanded} />}
-      </span>
+      <label className={labelClasses} title={title || null}>
+        <span className={innerLabelClasses} style={{ width: '100%' }}>
+          {labelText}
+          {hasGroups && <CheckBoxIcon isExpanded={isExpanded} />}
+        </span>
+      </label>
     </div>
   );
 };

--- a/src/components/ListBox/ListBoxMenuIcon.js
+++ b/src/components/ListBox/ListBoxMenuIcon.js
@@ -29,7 +29,7 @@ const ListBoxMenuIcon = ({ isOpen, translateWithId: t }) => {
       <Icon
         icon={iconCaretDown}
         description={description}
-        name="iconName"
+        name="icon--caret--down"
         alt={description}
       />
     </div>

--- a/src/components/ListBox/ListBoxSelection.js
+++ b/src/components/ListBox/ListBoxSelection.js
@@ -47,7 +47,7 @@ const ListBoxSelection = ({
         icon={iconClose}
         description={description}
         focusable="false"
-        name={description}
+        name="icon--close"
       />
     </div>
   );

--- a/src/components/MultiSelect/NestedFilterableMultiselect.js
+++ b/src/components/MultiSelect/NestedFilterableMultiselect.js
@@ -283,7 +283,8 @@ export default class NestedFilterableMultiselect extends React.Component {
                   <ListBox.MenuIcon isOpen={isOpen} />
                 </ListBox.Field>
                 {isOpen && (
-                  <ListBox.Menu style={{ maxHeight: '424px' }}>
+                  <ListBox.Menu
+                    style={{ maxHeight: '424px', overflowX: 'hidden' }}>
                     {groupedByCategory(items).map((group, index) => {
                       const hasGroups = group[0] !== 'undefined' ? true : false;
                       let categoryName = '';
@@ -340,6 +341,7 @@ export default class NestedFilterableMultiselect extends React.Component {
                                   onClick={e => {
                                     {
                                       const clickOutOfCheckBox =
+                                        subOptions &&
                                         e.target.localName != 'label';
                                       if (clickOutOfCheckBox) {
                                         this.onToggle(item);


### PR DESCRIPTION
This PR fixes the following:
1) Move the span element back to the label element for a11y.
2) Fix all the Icon to pass the name of the SVG icon to look up.
3) Fix the click behavior so that clicking the name will not check the checkbox if it has group children