### PR TITLE
fix(filters): fix filtering of child items

### DIFF
--- a/src/components/MultiSelect/NestedFilterableMultiselect.js
+++ b/src/components/MultiSelect/NestedFilterableMultiselect.js
@@ -392,6 +392,7 @@ export default class NestedFilterableMultiselect extends React.Component {
                                       itemToString,
                                       compareItems,
                                       locale,
+                                      parent: item,
                                     }
                                   ).map((item, index) => {
                                     const optionsProps = getItemProps({ item });

--- a/src/components/MultiSelect/NestedFilterableMultiselect.js
+++ b/src/components/MultiSelect/NestedFilterableMultiselect.js
@@ -11,7 +11,7 @@ import { sortingPropTypes } from './MultiSelectPropTypes';
 import { defaultItemToString } from './tools/itemToString';
 import { groupedByCategory } from './tools/groupedByCategory';
 import { defaultSortItems, defaultCompareItems } from './tools/sorting';
-import { defaultFilterItems } from '../ComboBox/tools/filter';
+import { defaultFilterItems } from './tools/filter';
 
 export default class NestedFilterableMultiselect extends React.Component {
   static propTypes = {
@@ -381,7 +381,19 @@ export default class NestedFilterableMultiselect extends React.Component {
 
                                 {groupIsOpen &&
                                   subOptions != undefined &&
-                                  subOptions.map((item, index) => {
+                                  sortItems(
+                                    filterItems(subOptions, {
+                                      itemToString,
+                                      inputValue,
+                                      parent: item,
+                                    }),
+                                    {
+                                      selectedItems,
+                                      itemToString,
+                                      compareItems,
+                                      locale,
+                                    }
+                                  ).map((item, index) => {
                                     const optionsProps = getItemProps({ item });
                                     const isCheckedSub = item.checked;
                                     const subOpText = itemToString(item);

--- a/src/components/MultiSelect/tools/filter.js
+++ b/src/components/MultiSelect/tools/filter.js
@@ -1,0 +1,33 @@
+export const defaultFilterItems = (
+  items,
+  { itemToString, inputValue, parent }
+) =>
+  items.filter(item => {
+    if (!inputValue) {
+      return true;
+    }
+    if (item.options) {
+      // if any of the child item matches, the parent item should be shown
+      const isMatch =
+        item.options.filter(option =>
+          itemToString(option)
+            .toLowerCase()
+            .includes(inputValue.toLowerCase())
+        ).length > 0;
+      if (isMatch) {
+        return true;
+      }
+    }
+    if (parent) {
+      // if it matches the parent, all sub items should be shown
+      const isMatch = itemToString(parent)
+        .toLowerCase()
+        .includes(inputValue.toLowerCase());
+      if (isMatch) {
+        return true;
+      }
+    }
+    return itemToString(item)
+      .toLowerCase()
+      .includes(inputValue.toLowerCase());
+  });

--- a/src/components/MultiSelect/tools/sorting.js
+++ b/src/components/MultiSelect/tools/sorting.js
@@ -18,7 +18,7 @@ export const defaultCompareItems = (itemA, itemB, { locale }) =>
  */
 export const defaultSortItems = (
   items,
-  { selectedItems, itemToString, compareItems, locale = 'en' }
+  { selectedItems, itemToString, compareItems, locale = 'en', parent }
 ) =>
   items.sort((itemA, itemB) => {
     const hasItemA = selectedItems.includes(itemA);
@@ -31,6 +31,20 @@ export const defaultSortItems = (
 
     if (hasItemB && !hasItemA) {
       return 1;
+    }
+
+    if (parent) {
+      const checkedItemA = itemA.checked;
+      const checkedItemB = itemB.checked;
+
+      // Prefer whichever checked item be first
+      if (checkedItemA && !checkedItemB) {
+        return -1;
+      }
+
+      if (checkedItemB && !checkedItemA) {
+        return 1;
+      }
     }
 
     return compareItems(itemToString(itemA), itemToString(itemB), {


### PR DESCRIPTION
This PR fixes the filtering of child items. When typing a value in the search box, it should also filter the child items. The rules are:
- if the text matches the parent label, the parent and all its children will be visible
- if the text matches the child label, the parent and the matching children will be visible.